### PR TITLE
Omit `require 'spec_helper'`

### DIFF
--- a/spec/gry/cli_spec.rb
+++ b/spec/gry/cli_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'stringio'
 
 describe Gry::CLI do

--- a/spec/gry/congress_spec.rb
+++ b/spec/gry/congress_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Gry::Congress do
   describe '#discuss' do
     subject(:discuss) do

--- a/spec/gry/formatter_spec.rb
+++ b/spec/gry/formatter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Gry::Formatter do
   let(:fmt){Gry::Formatter.new(display_disabled_cops: display_disabled_cops)}
   let(:display_disabled_cops){false}

--- a/spec/gry/pilot_study_spec.rb
+++ b/spec/gry/pilot_study_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Gry::PilotStudy do
   describe '#analyze' do
     break if ENV['DONT_RUN_SLOW_SPEC']

--- a/spec/gry/rubocop_adapter_spec.rb
+++ b/spec/gry/rubocop_adapter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Gry::RubocopAdapter do
   describe '.default_config' do
     it 'returns a RuboCop::Config' do

--- a/spec/gry/rubocop_runner_spec.rb
+++ b/spec/gry/rubocop_runner_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Gry::RubocopRunner do
   describe '.new' do
     it 'sets @setting' do


### PR DESCRIPTION
The `--require spec_helper` option was already specified in .rspec file.

https://github.com/pocke/gry/blob/f739203d28a75be663536b9a467709c03c703860/.rspec#L2