### PR TITLE
Fix broken gry v0.5.1

### DIFF
--- a/lib/gry/cli.rb
+++ b/lib/gry/cli.rb
@@ -40,7 +40,7 @@ module Gry
     end
 
     def save_cache(bills, cops)
-      Dir.mkdir(cache_dir) unless CACHE_DIR.exist?
+      Dir.mkdir(CACHE_DIR) unless CACHE_DIR.exist?
       cache = {
         bills: bills,
         cops: cops,


### PR DESCRIPTION
The following error has occurred in gry v0.5.1.

```
$ gry >> .rubocop.yml
/Users/watanabekazuma/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/gry-0.5.1/lib/gry/cli.rb:43:in `save_cache': undefined local variable or method `cache_dir' for #<Gry::CLI:0x007fb9f39414e8 @argv=[]> (NameError)
Did you mean?  cache
        from /Users/watanabekazuma/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/gry-0.5.1/lib/gry/cli.rb:25:in `block in run'
        from /Users/watanabekazuma/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/gry-0.5.1/lib/gry/cli.rb:24:in `tap'
        from /Users/watanabekazuma/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/gry-0.5.1/lib/gry/cli.rb:24:in `run'
        from /Users/watanabekazuma/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/gry-0.5.1/exe/gry:5:in `<top (required)>'
        from /Users/watanabekazuma/.rbenv/versions/2.4.1/bin/gry:22:in `load'
        from /Users/watanabekazuma/.rbenv/versions/2.4.1/bin/gry:22:in `<main>'
```

Perhaps this is a simple bug that occurred when introducing the caching mechanism. (I don't know why it passed Travis CI...)