### PR TITLE
Change rubocop github repository

### DIFF
--- a/gemfiles/rubocop_head.gemfile
+++ b/gemfiles/rubocop_head.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rubocop", :github => "bbatsov/rubocop"
+gem "rubocop", :github => "rubocop-hq/rubocop"
 
 gemspec :path => "../"


### PR DESCRIPTION
bbatsov/rubocop was moved to under rubocop-hq org.